### PR TITLE
캘린더 생성

### DIFF
--- a/src/components/borad/StatusList.ts
+++ b/src/components/borad/StatusList.ts
@@ -90,7 +90,7 @@ export default class StatusList extends HTMLElement {
         const newStatusId = await createStatus(this._newStatusTitle);
         this.applyStatusUI(newStatusId, this._newStatusTitle);
       } catch (error: any) {
-        console.log(error);
+        console.log(error.message);
       }
     });
   }
@@ -102,7 +102,7 @@ export default class StatusList extends HTMLElement {
         this.applyStatusUI(status.id, status.statusTitle);
       });
     } catch (error: any) {
-      console.log(error);
+      console.log(error.message);
     }
   }
 

--- a/src/components/borad/TaskList.ts
+++ b/src/components/borad/TaskList.ts
@@ -81,22 +81,27 @@ export default class TaskList extends HTMLElement {
 
   render() {
     this.innerHTML = `
-      <ul>
-        ${this._list
-          ?.map((task: ITask) => {
-            return `
+    <ul>
+    ${this._list
+      ?.map((task: ITask) => {
+        const isSameDate = task.startDate === task.endDate;
+        const isToday = task.startDate === new Date().toISOString().split('T')[0];
+
+        let dateStr = '';
+        if (isSameDate && isToday) {
+          dateStr = 'Today';
+        } else if (isSameDate) {
+          dateStr = `<time>${formatDate(task.startDate)}</time>`;
+        } else {
+          dateStr = `<time>${formatDate(task.startDate)}</time> ~ <time>${formatDate(task.endDate)}</time>`;
+        }
+        return `
                   <li data-task-id="${task.id}">
                     <article class="task-card ${task.priority.toLowerCase()}">
                       <header class="task-card-header">
                         <span class="date-wrapper">
                           <img src="${date}" alt="date">
-                          ${
-                            task.startDate === task.endDate && task.startDate === new Date().toISOString().split('T')[0]
-                              ? 'Today'
-                              : task.startDate === task.endDate
-                                ? `<time>${formatDate(task.startDate)}</time>`
-                                : `<time>${formatDate(task.startDate)}</time> ~ <time>${formatDate(task.endDate)}</time>`
-                          }
+                          ${dateStr}
                         </span>
                         <span class="priority">${task.priority} priority</span>
                       </header>
@@ -107,8 +112,8 @@ export default class TaskList extends HTMLElement {
                     </article>
                   </li>
             `;
-          })
-          .join('')}
+      })
+      .join('')}
       </ul>
 `;
   }

--- a/src/components/calendar/Agenda.ts
+++ b/src/components/calendar/Agenda.ts
@@ -1,0 +1,17 @@
+export default class Agenda extends HTMLElement {
+  connectedCallback() {
+    this.render();
+    this.loadStatus();
+  }
+
+  private loadStatus() {}
+
+  render() {
+    this.innerHTML = `
+        <div class="agendar">
+        </div>
+    `;
+  }
+}
+
+customElements.define('agenda-element', Agenda);

--- a/src/components/calendar/Agenda.ts
+++ b/src/components/calendar/Agenda.ts
@@ -9,15 +9,15 @@ export default class Agenda extends HTMLElement {
   }
   connectedCallback() {
     this.render();
-    this.loadStatus();
+    this.renderTasks();
   }
 
   set monthlyTasks(tasks: ITask[]) {
     this._monthlyTasks = tasks;
-    this.loadStatus();
+    this.renderTasks();
   }
 
-  private loadStatus() {
+  private renderTasks() {
     const $agenda = document.querySelector('.agenda');
     if ($agenda) {
       $agenda.innerHTML = `

--- a/src/components/calendar/Agenda.ts
+++ b/src/components/calendar/Agenda.ts
@@ -1,14 +1,44 @@
+import { ITask } from 'types/types';
+
 export default class Agenda extends HTMLElement {
+  private _monthlyTasks: ITask[];
+
+  constructor() {
+    super();
+    this._monthlyTasks = [];
+  }
   connectedCallback() {
     this.render();
     this.loadStatus();
   }
 
-  private loadStatus() {}
+  set monthlyTasks(tasks: ITask[]) {
+    this._monthlyTasks = tasks;
+    this.loadStatus();
+  }
+
+  private loadStatus() {
+    const $agenda = document.querySelector('.agenda');
+    if ($agenda) {
+      $agenda.innerHTML = `
+      ${this._monthlyTasks
+        .map(
+          (task) => `
+          <div class="task-wrapper">
+            <div class="priority-color ${task.priority}"></div>
+            <time>${task.startDate.slice(5)} ~ ${task.endDate.slice(5)}</time>
+            <div>${task.title}</div>
+          </div>
+        `,
+        )
+        .join('')}
+      `;
+    }
+  }
 
   render() {
     this.innerHTML = `
-        <div class="agendar">
+        <div class="agenda">
         </div>
     `;
   }

--- a/src/components/calendar/Calendar.ts
+++ b/src/components/calendar/Calendar.ts
@@ -133,11 +133,19 @@ export default class Calendar extends HTMLElement {
   }
 
   private applyStatusUI(data: ITask[]) {
+    const taskRowIndexMap = new Map<number, number>();
+    let nextAvailableRowIndex = 0;
+
     data.forEach((task) => {
+      // rowIndex 있는지 쳌
+      if (!taskRowIndexMap.has(Number(task.id))) {
+        taskRowIndexMap.set(Number(task.id), nextAvailableRowIndex);
+        nextAvailableRowIndex++;
+      }
+      const rowIndex = taskRowIndexMap.get(Number(task.id))!;
+
       const start = new Date(task.startDate);
       const end = new Date(task.endDate);
-
-      // start ~ end 라벨부착
       let current = new Date(start);
 
       while (current <= end) {
@@ -145,12 +153,16 @@ export default class Calendar extends HTMLElement {
         const $cell = this.querySelector<HTMLDivElement>(`.day-cell[data-date="${dateStr}"]`);
         if ($cell) {
           const $taskBar = document.createElement('div');
-          $taskBar.classList.add('task-bar');
-          $taskBar.textContent = task.title;
-          $taskBar.dataset.taskId = String(task.id);
+          $taskBar.classList.add('task-bar', 'priority-color', `${task.priority}`);
+          $taskBar.style.top = `${rowIndex * 30 + 20}px`;
+          $taskBar.style.borderRadius = '0';
+
+          if (dateStr === formatDashDate(start) || current.getDay() === 0) {
+            $taskBar.textContent = task.title;
+          }
+
           $cell.appendChild($taskBar);
         }
-
         current.setDate(current.getDate() + 1);
       }
     });

--- a/src/components/calendar/Calendar.ts
+++ b/src/components/calendar/Calendar.ts
@@ -81,7 +81,7 @@ export default class Calendar extends HTMLElement {
       this.year -= 1;
     } else if (this.month > 11) {
       this.month = 0;
-      this.year + 1;
+      this.year += 1;
     }
     this.render();
     this.loadStatus();

--- a/src/components/calendar/Calendar.ts
+++ b/src/components/calendar/Calendar.ts
@@ -2,6 +2,7 @@ import { createIconButton } from '../common/button/buttonTemplates';
 import leftIcon from '@/assets/caret-left-fill.svg';
 import rightIcon from '@/assets/caret-right-fill.svg';
 import { getTasksByMonth } from '@/data/indexedDBService';
+import Agenda from '@/components/calendar/Agenda';
 
 export default class Calendar extends HTMLElement {
   MONTH_NAMES: string[];
@@ -39,14 +40,14 @@ export default class Calendar extends HTMLElement {
     for (let i = 0; i < startDay; i++) {
       const prevMonthday = prevLastDate - startDay + (i + 1);
       cells += `
-          <div >
+          <div class="day-cell">
               <span class="day-num prev-month-day">${prevMonthday}</span>
           </div>`;
     }
 
     for (let thisMonthday = 1; thisMonthday <= thisLastDate; thisMonthday++) {
       cells += `
-          <div>
+          <div class="day-cell">
               <span class="day-num">${thisMonthday}</span>
           </div>
       `;
@@ -57,7 +58,7 @@ export default class Calendar extends HTMLElement {
     const nextDays = totalCellCount - totalCellUsed;
     for (let nextMonthDay = 1; nextMonthDay <= nextDays; nextMonthDay++) {
       cells += `
-          <div>
+          <div class="day-cell">
               <span class="day-num next-month-day">${nextMonthDay}</span>
           </div>
       `;
@@ -92,9 +93,15 @@ export default class Calendar extends HTMLElement {
   private async loadStatus() {
     try {
       const monthStr = this.month < 10 ? '0' + (this.month + 1) : this.month + 1;
-      const monthData = await getTasksByMonth(`${this.year}-${monthStr}`);
-      // TODO: monthData를 기반으로 agenda 그리기
-      console.log('🐽', monthData);
+      const monthlyData = await getTasksByMonth(`${this.year}-${monthStr}`);
+      // TODO: monthlyData를 기반으로 calendar에 task 라벨 표시
+      const $calendarContents = this.closest('calendar-contents');
+      if (!$calendarContents) {
+        return;
+      }
+      const $agenda = $calendarContents.querySelector('agenda-element') as Agenda;
+
+      $agenda.monthlyTasks = monthlyData;
     } catch (error: any) {
       console.log(error);
     }

--- a/src/components/calendar/Calendar.ts
+++ b/src/components/calendar/Calendar.ts
@@ -107,6 +107,12 @@ export default class Calendar extends HTMLElement {
 
         if (taskId) {
           $editorModal.taskId = taskId;
+
+          $editorModal.addEventListener('update-complete', () => {
+            this.render();
+            this.loadStatus();
+          });
+
           document.body.appendChild($editorModal);
         }
       }
@@ -156,6 +162,8 @@ export default class Calendar extends HTMLElement {
           $taskBar.classList.add('task-bar', 'priority-color', `${task.priority}`);
           $taskBar.style.top = `${rowIndex * 30 + 20}px`;
           $taskBar.style.borderRadius = '0';
+
+          $taskBar.dataset.taskId = String(task.id);
 
           if (dateStr === formatDashDate(start) || current.getDay() === 0) {
             $taskBar.textContent = task.title;

--- a/src/components/calendar/Calendar.ts
+++ b/src/components/calendar/Calendar.ts
@@ -134,7 +134,7 @@ export default class Calendar extends HTMLElement {
 
       $agenda.monthlyTasks = monthlyData;
     } catch (error: any) {
-      console.log(error);
+      console.log(error.message);
     }
   }
 

--- a/src/components/calendar/Calendar.ts
+++ b/src/components/calendar/Calendar.ts
@@ -1,0 +1,121 @@
+import { createIconButton } from '../common/button/buttonTemplates';
+import leftIcon from '@/assets/caret-left-fill.svg';
+import rightIcon from '@/assets/caret-right-fill.svg';
+import { getTasksByMonth } from '@/data/indexedDBService';
+
+export default class Calendar extends HTMLElement {
+  MONTH_NAMES: string[];
+  WEEK: string[];
+  date: Date;
+  today: number;
+  month: number;
+  year: number;
+  constructor() {
+    super();
+    const date = new Date();
+    this.MONTH_NAMES = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AGU', 'SEP', 'OCT', 'NOV', 'DEC'];
+    this.WEEK = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    this.date = new Date();
+    this.today = date.getDate();
+    this.month = date.getMonth();
+    this.year = date.getFullYear();
+  }
+
+  connectedCallback() {
+    this.render();
+    this.generateCalendarCell();
+    this.setupButtonClickListeners();
+    this.loadStatus();
+  }
+
+  private generateCalendarCell() {
+    // 현대 달(앞뒤 달 자투리 날짜 포함)
+    const firstDay = new Date(this.year, this.month, +1);
+    const startDay = firstDay.getDay(); //달의 시작 요일
+    const thisLastDate = new Date(this.year, this.month + 1, 0).getDate();
+    const prevLastDate = new Date(this.year, this.month, 0).getDate();
+
+    let cells = '';
+    for (let i = 0; i < startDay; i++) {
+      const prevMonthday = prevLastDate - startDay + (i + 1);
+      cells += `
+          <div >
+              <span class="day-num prev-month-day">${prevMonthday}</span>
+          </div>`;
+    }
+
+    for (let thisMonthday = 1; thisMonthday <= thisLastDate; thisMonthday++) {
+      cells += `
+          <div>
+              <span class="day-num">${thisMonthday}</span>
+          </div>
+      `;
+    }
+
+    const totalCellCount = 42;
+    const totalCellUsed = startDay + thisLastDate;
+    const nextDays = totalCellCount - totalCellUsed;
+    for (let nextMonthDay = 1; nextMonthDay <= nextDays; nextMonthDay++) {
+      cells += `
+          <div>
+              <span class="day-num next-month-day">${nextMonthDay}</span>
+          </div>
+      `;
+    }
+    return cells;
+  }
+
+  private handleMonthChange(directionNum: number) {
+    this.month += directionNum;
+    if (this.month < 0) {
+      this.month = 11;
+      this.year -= 1;
+    } else if (this.month > 11) {
+      this.month = 0;
+      this.year + 1;
+    }
+    this.render();
+    this.loadStatus();
+  }
+
+  private setupButtonClickListeners() {
+    this.addEventListener('click', (event: Event) => {
+      const $target = event.target as HTMLElement;
+      if ($target.closest('.prev-button')) {
+        this.handleMonthChange(-1);
+      } else if ($target.closest('.next-button')) {
+        this.handleMonthChange(1);
+      }
+    });
+  }
+
+  private async loadStatus() {
+    try {
+      const monthStr = this.month < 10 ? '0' + (this.month + 1) : this.month + 1;
+      const monthData = await getTasksByMonth(`${this.year}-${monthStr}`);
+      // TODO: monthData를 기반으로 agenda 그리기
+      console.log('🐽', monthData);
+    } catch (error: any) {
+      console.log(error);
+    }
+  }
+
+  render() {
+    this.innerHTML = `
+    <div class="calendar-header">
+        ${createIconButton('prev-button', leftIcon, 'left-icon')}
+        <h2>${this.MONTH_NAMES[this.month]}</h2>
+        ${createIconButton('next-button', rightIcon, 'next-icon')}
+    </div>
+    <div class="calendar">
+        <div class="week-days">
+            ${this.WEEK.map((day) => `<div>${day}</div>`).join('')}
+        </div>
+        <div class="calendar-grid">${this.generateCalendarCell()}
+        </div>
+    </div>
+    `;
+  }
+}
+
+customElements.define('calendar-element', Calendar);

--- a/src/components/calendar/CalendarContenst.ts
+++ b/src/components/calendar/CalendarContenst.ts
@@ -1,0 +1,21 @@
+import '@/components/calendar/Calendar';
+import '@/components/calendar/Agenda';
+
+export default class CalendarContents extends HTMLElement {
+  connectedCallback() {
+    this.render();
+    this.loadStatus();
+  }
+
+  private loadStatus() {}
+  render() {
+    this.innerHTML = `
+      <div class="calendar-contents">
+        <calendar-element></calendar-element>
+        <agenda-element></agenda-element>
+      </div>
+    `;
+  }
+}
+
+customElements.define('calendar-contents', CalendarContents);

--- a/src/components/calendar/CalendarContenst.ts
+++ b/src/components/calendar/CalendarContenst.ts
@@ -4,10 +4,8 @@ import '@/components/calendar/Agenda';
 export default class CalendarContents extends HTMLElement {
   connectedCallback() {
     this.render();
-    this.loadStatus();
   }
 
-  private loadStatus() {}
   render() {
     this.innerHTML = `
         <div class="calendar-contents">

--- a/src/components/calendar/CalendarContenst.ts
+++ b/src/components/calendar/CalendarContenst.ts
@@ -10,10 +10,10 @@ export default class CalendarContents extends HTMLElement {
   private loadStatus() {}
   render() {
     this.innerHTML = `
-      <div class="calendar-contents">
-        <calendar-element></calendar-element>
-        <agenda-element></agenda-element>
-      </div>
+        <div class="calendar-contents">
+            <calendar-element></calendar-element>
+            <agenda-element></agenda-element>
+        </div>
     `;
   }
 }

--- a/src/components/common/Contents.ts
+++ b/src/components/common/Contents.ts
@@ -17,7 +17,7 @@ export default class Contents extends HTMLElement {
     this._totalCount = 0;
   }
 
-  async connectedCallback() {
+  connectedCallback() {
     this.render();
     this.handleAddNewButtonClick();
     this.updateTotalTaskCount();
@@ -72,19 +72,23 @@ export default class Contents extends HTMLElement {
       const cancelHandler = () => {
         document.body.removeChild($confirmDialog);
       };
-      const confirmHandler = () => {
-        document.body.removeChild($confirmDialog);
-        const $statusList = this.querySelector('status-list') as HTMLElement;
+      const confirmHandler = async () => {
+        try {
+          document.body.removeChild($confirmDialog);
+          const $statusList = this.querySelector('status-list') as HTMLElement;
 
-        if ($statusList) {
-          const $targetButton = event.target as HTMLElement;
-          const $taskList = $targetButton.closest('ul.task-list') as HTMLUListElement | null;
+          if ($statusList) {
+            const $targetButton = event.target as HTMLElement;
+            const $taskList = $targetButton.closest('ul.task-list') as HTMLUListElement | null;
 
-          if ($taskList) {
-            deleteStatus(Number($taskList.dataset.id));
-            $taskList.remove();
-            this.updateTotalTaskCount();
+            if ($taskList) {
+              await deleteStatus(Number($taskList.dataset.id));
+              $taskList.remove();
+              this.updateTotalTaskCount();
+            }
           }
+        } catch (error: any) {
+          console.log(error.message);
         }
       };
       const $confirmDialog = createConfirmDialog(

--- a/src/components/common/Contents.ts
+++ b/src/components/common/Contents.ts
@@ -1,5 +1,6 @@
 import '@/components/common/ActionGroup';
 import '@/components/borad/StatusList';
+import '@/components/calendar/CalendarContenst';
 import StatusList from '@/components/borad/StatusList';
 import ActionGroup from '@/components/common/ActionGroup';
 import { deleteStatus } from '@/data/indexedDBService';
@@ -102,7 +103,7 @@ export default class Contents extends HTMLElement {
     this.innerHTML = `
         <section class="contents">
             <action-group></action-group>
-            ${selectedTab === 'Board' ? '<status-list></status-list>' : '<calendar>캘린더</calendar>'}
+            ${selectedTab === 'Board' ? '<status-list></status-list>' : '<calendar-contents>캘린더</calendar-contents>'}
         </section>
     `;
   }

--- a/src/components/common/modal/EditorModal.ts
+++ b/src/components/common/modal/EditorModal.ts
@@ -113,6 +113,9 @@ export default class EiditorModal extends HTMLElement {
                   await createTask(taskData);
                 }
 
+                const event = new CustomEvent('update-complete', { bubbles: true });
+                this.dispatchEvent(event);
+
                 const $taskList = document.querySelector(
                   `ul.task-list[data-id="${taskData.statusId}"] task-list`,
                 ) as TaskList;

--- a/src/components/common/modal/EditorModal.ts
+++ b/src/components/common/modal/EditorModal.ts
@@ -5,6 +5,7 @@ import { TPriorities } from 'types/types';
 import { createTask, getTasks, updateTask } from '@/data/indexedDBService';
 import { createConfirmDialog } from '@/components/common/modal/ModalTemplates';
 import TaskList from '@/components/borad/TaskList';
+import { getMonthsBetween } from '@/util/helpers';
 
 export default class EiditorModal extends HTMLElement {
   selectedPriority: TPriorities;
@@ -15,6 +16,8 @@ export default class EiditorModal extends HTMLElement {
   _showSaveButton: boolean;
   _statusId: string | null;
   _taskId: string | null;
+  _startMonth: string;
+  _endMonth: string;
 
   constructor() {
     const today = new Date().toISOString().split('T')[0];
@@ -27,6 +30,8 @@ export default class EiditorModal extends HTMLElement {
     this._showSaveButton = false;
     this._statusId = null;
     this._taskId = null;
+    this._startMonth = '';
+    this._endMonth = '';
   }
   connectedCallback() {
     this.render();
@@ -83,6 +88,7 @@ export default class EiditorModal extends HTMLElement {
             description: this._description || '',
             priority: this.selectedPriority,
             statusId: this._statusId,
+            months: getMonthsBetween(this._startDate, this._endDate),
           };
 
           if (!this._title || !this._startDate || !this._endDate) {

--- a/src/components/common/modal/EditorModal.ts
+++ b/src/components/common/modal/EditorModal.ts
@@ -125,7 +125,7 @@ export default class EiditorModal extends HTMLElement {
                 document.body.removeChild(this);
                 return;
               } catch (error: any) {
-                console.log(error);
+                console.log(error.message);
               }
             };
             const cancelHandler = () => {

--- a/src/data/dbConfig.ts
+++ b/src/data/dbConfig.ts
@@ -15,7 +15,7 @@ export function openDatabase(): Promise<IDBDatabase> {
 
     request.onerror = (event: Event) => {
       const $target = event.target as IDBRequest;
-      reject($target.error);
+      reject(new Error($target.error?.message || 'IndexedDB error'));
       console.error('Database error:', $target.error);
     };
 

--- a/src/data/dbConfig.ts
+++ b/src/data/dbConfig.ts
@@ -1,5 +1,5 @@
 export const DB_NAME = 'SchedulerDB';
-export const DB_VERSION = 6;
+export const DB_VERSION = 7;
 export const STATUS_STORE = 'status';
 export const TASK_STORE = 'tasks';
 
@@ -38,6 +38,13 @@ export function openDatabase(): Promise<IDBDatabase> {
           autoIncrement: true,
         });
         objectStore.createIndex('statusId', 'statusId', { unique: false });
+        objectStore.createIndex('months', 'months', { multiEntry: true });
+      } else {
+        const transaction = request.transaction;
+        const store = transaction?.objectStore(TASK_STORE);
+        if (store && !store.indexNames.contains('months')) {
+          store.createIndex('months', 'months', { multiEntry: true });
+        }
       }
     };
 

--- a/src/data/indexedDBService.ts
+++ b/src/data/indexedDBService.ts
@@ -128,6 +128,21 @@ export async function getTasksByStatus(statusId: string): Promise<ITask[]> {
     };
   });
 }
+export async function getTasksByMonth(month: string): Promise<ITask[]> {
+  const db = await openDatabase();
+  const transaction = db.transaction([TASK_STORE], 'readonly');
+  const store = transaction.objectStore(TASK_STORE);
+  // statusId 인덱스로 검색
+  const index = store.index('months');
+  const request = index.getAll(month);
+
+  return new Promise((resolve, reject) => {
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      resolve(request.result as ITask[]);
+    };
+  });
+}
 
 export async function updateTask(taskId: number, updatedFields: Partial<ITask>): Promise<void> {
   const db = await openDatabase();

--- a/src/data/indexedDBService.ts
+++ b/src/data/indexedDBService.ts
@@ -12,7 +12,7 @@ export async function createStatus(statusTitle: string): Promise<number> {
   return new Promise((resolve, reject) => {
     const checkRequest = index.get(statusTitle);
 
-    checkRequest.onerror = () => reject(checkRequest.error);
+    checkRequest.onerror = () => reject(new Error(checkRequest.error?.message || 'IndexedDB error'));
     checkRequest.onsuccess = () => {
       if (checkRequest.result) {
         const message = '동일한 리스트명이 존재합니다.';
@@ -27,7 +27,7 @@ export async function createStatus(statusTitle: string): Promise<number> {
         return;
       }
       const addRequest = store.add({ statusTitle, taskCount: 0 });
-      addRequest.onerror = () => reject(addRequest.error);
+      addRequest.onerror = () => reject(new Error(addRequest.error?.message || 'IndexedDB error'));
       addRequest.onsuccess = () => resolve(addRequest.result as number);
     };
   });
@@ -39,7 +39,7 @@ export async function getStatus(statusId: number): Promise<IStatusList | undefin
   const store = transaction.objectStore(STATUS_STORE);
   const request = store.get(statusId);
   return new Promise((resolve, reject) => {
-    request.onerror = () => reject(request.error);
+    request.onerror = () => reject(new Error(request.error?.message || 'IndexedDB error'));
     request.onsuccess = () => resolve(request.result);
   });
 }
@@ -51,7 +51,7 @@ export async function getAllStatuses(): Promise<IStatusList[]> {
   const request = store.getAll();
 
   return new Promise((resolve, reject) => {
-    request.onerror = () => reject(request.error);
+    request.onerror = () => reject(new Error(request.error?.message || 'IndexedDB error'));
     request.onsuccess = () => resolve(request.result as IStatusList[]);
   });
 }
@@ -63,7 +63,7 @@ export async function updateStatus(statusId: number, newTitle: string): Promise<
   // 데이터를 가져오고 수정하는 방식
   const request = store.get(statusId);
   return new Promise((resolve, reject) => {
-    request.onerror = () => reject(request.error);
+    request.onerror = () => reject(new Error(request.error?.message || 'IndexedDB error'));
     request.onsuccess = () => {
       const statusList = request.result as IStatusList;
       if (!statusList) {
@@ -71,7 +71,7 @@ export async function updateStatus(statusId: number, newTitle: string): Promise<
       }
       statusList.statusTitle = newTitle;
       const updateRequest = store.put(statusList);
-      updateRequest.onerror = () => reject(updateRequest.error);
+      updateRequest.onerror = () => reject(new Error(updateRequest.error?.message || 'IndexedDB error'));
       updateRequest.onsuccess = () => resolve();
     };
   });
@@ -86,18 +86,18 @@ export async function deleteStatus(statusId: number): Promise<void> {
   return new Promise((resolve, reject) => {
     const deleteStatusReq = statusStore.delete(statusId);
 
-    deleteStatusReq.onerror = () => reject(deleteStatusReq.error);
+    deleteStatusReq.onerror = () => reject(new Error(deleteStatusReq.error?.message || 'IndexedDB error'));
     deleteStatusReq.onsuccess = () => {
       // statusId에 종속된 Task 모두 삭제
       const index = taskStore.index('statusId');
       const cursorReq = index.openCursor(String(statusId));
 
-      cursorReq.onerror = () => reject(cursorReq.error);
+      cursorReq.onerror = () => reject(new Error(cursorReq.error?.message || 'IndexedDB error'));
       cursorReq.onsuccess = (e) => {
         const cursor = (e.target as IDBRequest<IDBCursorWithValue>).result;
         if (cursor) {
           const deleteTaskReq = cursor.delete();
-          deleteTaskReq.onerror = () => reject(deleteTaskReq.error);
+          deleteTaskReq.onerror = () => reject(new Error(deleteTaskReq.error?.message || 'IndexedDB error'));
           deleteTaskReq.onsuccess = () => cursor.continue();
         } else {
           resolve();
@@ -115,7 +115,7 @@ export async function createTask(task: ITask): Promise<number> {
   const request = store.add(task);
 
   return new Promise((resolve, reject) => {
-    request.onerror = () => reject(request.error);
+    request.onerror = () => reject(new Error(request.error?.message || 'IndexedDB error'));
     request.onsuccess = () => resolve(request.result as number);
   });
 }
@@ -126,7 +126,7 @@ export async function getTasks(taskId: number): Promise<ITask | undefined> {
   const store = transaction.objectStore(TASK_STORE);
   const request = store.get(taskId);
   return new Promise((resolve, reject) => {
-    request.onerror = () => reject(request.error);
+    request.onerror = () => reject(new Error(request.error?.message || 'IndexedDB error'));
     request.onsuccess = () => resolve(request.result);
   });
 }
@@ -140,7 +140,7 @@ export async function getTasksByStatus(statusId: string): Promise<ITask[]> {
   const request = index.getAll(statusId);
 
   return new Promise((resolve, reject) => {
-    request.onerror = () => reject(request.error);
+    request.onerror = () => reject(new Error(request.error?.message || 'IndexedDB error'));
     request.onsuccess = () => {
       resolve(request.result as ITask[]);
     };
@@ -155,7 +155,7 @@ export async function getTasksByMonth(month: string): Promise<ITask[]> {
   const request = index.getAll(month);
 
   return new Promise((resolve, reject) => {
-    request.onerror = () => reject(request.error);
+    request.onerror = () => reject(new Error(request.error?.message || 'IndexedDB error'));
     request.onsuccess = () => {
       resolve(request.result as ITask[]);
     };
@@ -169,7 +169,7 @@ export async function updateTask(taskId: number, updatedFields: Partial<ITask>):
 
   const getReq = store.get(taskId);
   return new Promise((resolve, reject) => {
-    getReq.onerror = () => reject(getReq.error);
+    getReq.onerror = () => reject(new Error(getReq.error?.message || 'IndexedDB error'));
     getReq.onsuccess = () => {
       const existing = getReq.result as ITask;
       if (!existing) {
@@ -177,7 +177,7 @@ export async function updateTask(taskId: number, updatedFields: Partial<ITask>):
       }
       const updatedTask = { ...existing, ...updatedFields };
       const updateReq = store.put(updatedTask);
-      updateReq.onerror = () => reject(updateReq.error);
+      updateReq.onerror = () => reject(new Error(updateReq.error?.message || 'IndexedDB error'));
       updateReq.onsuccess = () => resolve();
     };
   });
@@ -190,7 +190,7 @@ export async function deleteTask(taskId: number): Promise<void> {
 
   const request = store.delete(taskId);
   return new Promise((resolve, reject) => {
-    request.onerror = () => reject(request.error);
+    request.onerror = () => reject(new Error(request.error?.message || 'IndexedDB error'));
     request.onsuccess = () => resolve();
   });
 }

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,3 +1,4 @@
+//Month date. year
 export function formatDate(dateStr: string) {
   const date = new Date(dateStr);
   const options: Intl.DateTimeFormatOptions = {
@@ -9,6 +10,14 @@ export function formatDate(dateStr: string) {
   let formatted = new Intl.DateTimeFormat('en-US', options).format(date);
   formatted = formatted.replace(',', '.');
   return formatted;
+}
+
+//YYYY-MM-DD
+export function formatDashDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 export function getMonthsBetween(startDate: string, endDate: string): string[] {

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -10,3 +10,20 @@ export function formatDate(dateStr: string) {
   formatted = formatted.replace(',', '.');
   return formatted;
 }
+
+export function getMonthsBetween(startDate: string, endDate: string): string[] {
+  const result: string[] = [];
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+
+  let current = new Date(start.getFullYear(), start.getMonth(), 1);
+  const endMonth = new Date(end.getFullYear(), end.getMonth(), 1);
+
+  while (current <= endMonth) {
+    const year = current.getFullYear();
+    const month = String(current.getMonth() + 1).padStart(2, '0');
+    result.push(`${year}-${month}`);
+    current.setMonth(current.getMonth() + 1);
+  }
+  return result;
+}

--- a/style/_calendarContents.scss
+++ b/style/_calendarContents.scss
@@ -44,14 +44,11 @@
     text-align: center;
     padding: 20px;
     border-bottom: 1px solid colors.$light-gray;
-    border-right: 1px solid colors.$light-gray;
   }
 }
 .calendar-grid div {
   min-height: 100px;
-
   border-bottom: 1px solid colors.$light-gray;
-  border-right: 1px solid colors.$light-gray;
 }
 
 .day-cell span {
@@ -63,13 +60,18 @@
   display: flex;
   flex-direction: column;
   padding-top: 20px;
+
+  width: 100px;
+
   .task-bar {
+    height: 20px;
+    background-color: pink;
+
     margin-top: 4px;
     min-height: 20px;
     padding: 2px 2px 2px 5px;
     color: map.get(map.get(colors.$colors, font), taskDescription);
     font-size: 14px;
-    background-color: pink;
     display: inline-block;
     cursor: pointer;
   }

--- a/style/_calendarContents.scss
+++ b/style/_calendarContents.scss
@@ -1,0 +1,89 @@
+@use 'sass:map';
+@use './colors' as colors;
+@use './mixins' as mix;
+
+.calendar-contents {
+  display: flex;
+  justify-content: center;
+}
+
+.calendar {
+  width: 700px;
+  margin-right: 52px;
+  background-color: colors.$white;
+}
+
+.calendar-header {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  text-align: start;
+  margin: 30px 0 16px;
+  color: colors.$font-white;
+
+  .prev-button,
+  .next-button {
+    border: none;
+    background-color: transparent;
+
+    img {
+      width: 24px;
+    }
+    cursor: pointer;
+  }
+}
+.week-days,
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  width: 700px;
+  margin: 0 auto;
+}
+.week-days {
+  div {
+    text-align: center;
+    padding: 20px;
+    border-bottom: 1px solid colors.$light-gray;
+    border-right: 1px solid colors.$light-gray;
+  }
+}
+.calendar-grid div {
+  position: relative;
+  min-height: 80px;
+  padding: 4px;
+  border-bottom: 1px solid colors.$light-gray;
+  border-right: 1px solid colors.$light-gray;
+}
+.day-num {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.prev-month-day,
+.next-month-day {
+  color: map.get(map.get(colors.$colors, font), placeholder);
+}
+
+.agendar {
+  background-color: colors.$white;
+}
+.day-cell span {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+}
+.day-cell {
+  .event {
+  }
+}
+
+agenda-element {
+  .agendar {
+    background-color: map.get(map.get(colors.$colors, background), agenda);
+    width: 350px;
+    min-height: 488px;
+    margin-top: 75px;
+    padding: 50px;
+  }
+}

--- a/style/_calendarContents.scss
+++ b/style/_calendarContents.scss
@@ -65,11 +65,25 @@
   color: map.get(map.get(colors.$colors, font), placeholder);
 }
 
-.agendar {
+.agenda {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  color: colors.$white;
   background-color: colors.$white;
+  .priority-color {
+    width: 20px;
+    height: 20px;
+    border-radius: 5px;
+  }
+  .task-wrapper {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+  }
 }
 .day-cell span {
-  position: absolute;
+  position: relative;
   top: 4px;
   right: 4px;
 }
@@ -79,7 +93,7 @@
 }
 
 agenda-element {
-  .agendar {
+  .agenda {
     background-color: map.get(map.get(colors.$colors, background), agenda);
     width: 350px;
     min-height: 488px;

--- a/style/_calendarContents.scss
+++ b/style/_calendarContents.scss
@@ -48,18 +48,37 @@
   }
 }
 .calendar-grid div {
-  position: relative;
-  min-height: 80px;
-  padding: 4px;
+  min-height: 100px;
+
   border-bottom: 1px solid colors.$light-gray;
   border-right: 1px solid colors.$light-gray;
+}
+
+.day-cell span {
+  top: 4px;
+  right: 4px;
+}
+.day-cell {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding-top: 20px;
+  .task-bar {
+    margin-top: 4px;
+    min-height: 20px;
+    padding: 2px 2px 2px 5px;
+    color: map.get(map.get(colors.$colors, font), taskDescription);
+    font-size: 14px;
+    background-color: pink;
+    display: inline-block;
+    cursor: pointer;
+  }
 }
 .day-num {
   position: absolute;
   top: 12px;
   right: 12px;
 }
-
 .prev-month-day,
 .next-month-day {
   color: map.get(map.get(colors.$colors, font), placeholder);
@@ -80,15 +99,6 @@
     display: flex;
     gap: 10px;
     align-items: center;
-  }
-}
-.day-cell span {
-  position: relative;
-  top: 4px;
-  right: 4px;
-}
-.day-cell {
-  .event {
   }
 }
 

--- a/style/_colors.scss
+++ b/style/_colors.scss
@@ -22,14 +22,17 @@ $colors: (
     taskList: #836e8c80,
     count: #27083480,
     input: #6a6c93,
+    agenda: #47426b,
   ),
   border: (
     search: #a8a8a8,
     inputBottom: #001b41,
     editor: #8f8e8e,
+    lightGray: #ccc,
   ),
   button: (
     filter: #2d2a4f,
+    prevNext: #f7edff4d,
   ),
   hover: (
     add: #1c63fe,
@@ -54,3 +57,4 @@ $priorities: (
 );
 $task-list-bg: map.get(map.get($colors, background), taskList);
 $main-blue: map.get($colors, mainBlue);
+$light-gray: map.get(map.get($colors, border), lightGray);

--- a/style/_icon.scss
+++ b/style/_icon.scss
@@ -1,3 +1,6 @@
+@use 'sass:map';
+@use './colors' as colors;
+
 .plus-icon,
 .more-icon,
 .add-task-icon {
@@ -10,4 +13,8 @@
 .more-icon,
 .add-task-icon {
   filter: invert(100%);
+}
+
+.prev-icon,
+.next-icon {
 }

--- a/style/style.scss
+++ b/style/style.scss
@@ -6,6 +6,7 @@
 @use './icon';
 @use './boardContents';
 @use './modal';
+@use './calendarContents';
 
 @each $priority, $color in colors.$priorities {
   .#{$priority} {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -17,6 +17,9 @@ export interface ITask extends IDefaultInfo {
   description: string;
   statusId: string | null;
   taskId?: string; //수정 시에만 필요
+  months?: string[]; //calendar 달별로 가져올 때
+  // startMonth?: string;
+  // endMonth?: string;
 }
 
 export interface IStatusList {


### PR DESCRIPTION
- 캘린더 생성
  - board에서 생성한 값 가져와서 캘린더에 적용
  - 클릭 시 수정할 수 있게 구현
  - 오른쪽에 달별 스케줄 노출하는 아젠다 구현

- 구현 시 고민했던 부분
  - 기존 status, task 기준으로 데이터를 불러와 사용했다면, 달별로 보여줘하는 데이터 조회 기준점이 달라져서 indexedDB api 관리하는 파일에서 getTasksByMonth 추가하여 데이터 조회로 구현
  - 캘린더 구현 시 board에서 status 삭제 시 task도 연동되어 삭제하는 동작 누락 발견 -> 해당 부분도 indexedDB 의 status 삭제 관리 함수인 deleteStatus에서 task store 연결 하고 cursor로 종속 task 순회하며 삭제하는 로직 추가